### PR TITLE
fix: added missing quality-gates.yaml file

### DIFF
--- a/quality-gates.yaml
+++ b/quality-gates.yaml
@@ -1,0 +1,33 @@
+performance:
+  throughput:
+    error:
+      unstable: 0
+      failed: 5
+    response:
+      unstable: "default.jtl:100"
+
+security:
+  static:
+    high:
+      unstable: 0
+      failed: 0
+    medium:
+      unstable: 0
+      failed: 5
+  dynamic:
+    high:
+      unstable: 0
+      failed: 0
+    medium:
+      unstable: 0
+      failed: 5
+  dependencies:
+    critical:
+      unstable: 4
+      failed: 4
+    high:
+      unstable: 0
+      failed: 0
+    medium:
+      unstable: 5
+      failed: 5


### PR DESCRIPTION
(Issue #12)
The missing file **quality-gates.yaml** was added, following "La Hora Tech" video's original file.

The file provided was also tested by me, Jenkins build was successful.